### PR TITLE
Starboard Improvements

### DIFF
--- a/src/commands/moderation/ignore.js
+++ b/src/commands/moderation/ignore.js
@@ -12,17 +12,21 @@ module.exports = class extends Command {
     }
 
     execute(message, parameters, permissionLevel) {
-        const args = /(commands|invites)/i.exec(parameters);
+        const args = /(commands|invites|stars)/i.exec(parameters);
         if (!args) return message.error(this.client.functions.error("usage", this));
 
-        const commands = args[1] === "commands", invites = args[1] === "invites";
+        const commands = args[1] === "commands", invites = args[1] === "invites", stars = args[1] === "stars";
 
         if (commands && message.guild.settings.ignored.commands.includes(message.channel.id)) return message.error("This channel is already ignoring commands.");
         if (invites && message.guild.settings.ignored.invites.includes(message.channel.id)) return message.error("This channel is already ignoring invites.");
+        if (stars && message.guild.settings.ignored.stars.includes(message.channel.id)) {
+            if (!message.guild.settings.starboard.id) return message.error("The starboard is not enabled.");
+            return message.error("This channel is already ignoring stars.");
+        }
 
-        const newArray = message.guild.settings.ignored[commands ? "commands" : "invites"];
+        const newArray = message.guild.settings.ignored[args[1]];
         newArray.push(message.channel.id);
 
-        this.client.settings.update(message.guild.id, { ignored: { [commands ? "commands" : "invites"]: newArray } }).then(() => message.success(`Now ignoring ${commands ? "commands" : "invites"}.`));
+        this.client.settings.update(message.guild.id, { ignored: { [args[1]]: newArray } }).then(() => message.success(`Now ignoring ${args[1]}.`));
     }
 };

--- a/src/commands/moderation/ignore.js
+++ b/src/commands/moderation/ignore.js
@@ -5,7 +5,7 @@ module.exports = class extends Command {
     constructor(...args) {
         super(...args, {
             description: "Makes the bot ignore commands or invites in a channel.",
-            usage: "ignore ['commands'|'invites']",
+            usage: "ignore ['commands'|'invites'|'stars']",
             permission: Constants.Permissions.Levels.SERVER_ADMINISTRATOR,
             mode: Constants.Modes.STRICT
         });

--- a/src/commands/moderation/settings.js
+++ b/src/commands/moderation/settings.js
@@ -43,7 +43,7 @@ const settingsList = {
     "music-volume": "Change the required permission level for users to use the `volume` music command. Unless set to `off`, this overwrites the `music-permissions` setting.",
     "music-timelimit": "Change the maximum time limit for a video. Set in seconds. Minimum is 120 seconds (2 minutes). Maximum is 600 seconds (10 minutes). TypicalBot Prime Member maximum is 7200 seconds (2 hours).",
     "music-queuelimit": "Change the maximum queue limit for a video. Maximum is 10 videos. TypicalBot Prime Member maximum is 100 videos.",
-    "starboard": "A channel to send starred messages in. Aka starboard.",
+    "starboard": "A channel to send starred messages in, i.e. a starboard.",
     "starboard-stars": "Change the required stars count for messages to appear in the starboard."
 };
 
@@ -846,7 +846,7 @@ module.exports = class extends Command {
                         const n = Number(value);
 
                         if (isNaN(n)) return message.error("The given value is not a number.");
-                        if (n < 3) return message.error("The minimum value for this setting is 3 stars.");
+                        if (n < 1) return message.error("You can't star a message without at least one star.");
                         if (n > 10) return message.error("The maximum value for this setting is 10 stars.");
 
                         this.client.settings.update(message.guild.id, { starboard: { count: n } }).then(() => message.success("Setting successfully updated."));

--- a/src/commands/moderation/unignore.js
+++ b/src/commands/moderation/unignore.js
@@ -5,7 +5,7 @@ module.exports = class extends Command {
     constructor(...args) {
         super(...args, {
             description: "Makes the bot unignore commands or invites in a channel.",
-            usage: "unignore ['commands'|'invites']",
+            usage: "unignore ['commands'|'invites'|'stars']",
             permission: Constants.Permissions.Levels.SERVER_ADMINISTRATOR,
             mode: Constants.Modes.STRICT
         });
@@ -15,14 +15,14 @@ module.exports = class extends Command {
         const args = /(commands|invites)/i.exec(parameters);
         if (!args) return message.error(this.client.functions.error("usage", this));
 
-        const commands = args[1] === "commands", invites = args[1] === "invites";
+        const commands = args[1] === "commands", invites = args[1] === "invites", stars = args[1] === "stars";
 
         if (commands && !message.guild.settings.ignored.commands.includes(message.channel.id)) return message.error("This channel isn't ignoring commands.");
         if (invites && !message.guild.settings.ignored.invites.includes(message.channel.id)) return message.error("This channel isn't ignoring invites.");
 
-        const newArray = message.guild.settings.ignored[commands ? "commands" : "invites"];
+        const newArray = message.guild.settings.ignored[args[1]];
         newArray.splice(newArray.indexOf(message.channel.id), 1);
 
-        this.client.settings.update(message.guild.id, { ignored: { [commands ? "commands" : "invites"]: newArray } }).then(() => message.success(`Now listening to ${commands ? "commands" : "invites"}.`));
+        this.client.settings.update(message.guild.id, { ignored: { [args[1]]: newArray } }).then(() => message.success(`Now listening to ${args[1]}.`));
     }
 };

--- a/src/commands/moderation/unignore.js
+++ b/src/commands/moderation/unignore.js
@@ -12,7 +12,7 @@ module.exports = class extends Command {
     }
 
     execute(message, parameters, permissionLevel) {
-        const args = /(commands|invites)/i.exec(parameters);
+        const args = /(commands|invites|stars)/i.exec(parameters);
         if (!args) return message.error(this.client.functions.error("usage", this));
 
         const commands = args[1] === "commands", invites = args[1] === "invites", stars = args[1] === "stars";

--- a/src/commands/moderation/unignore.js
+++ b/src/commands/moderation/unignore.js
@@ -19,6 +19,10 @@ module.exports = class extends Command {
 
         if (commands && !message.guild.settings.ignored.commands.includes(message.channel.id)) return message.error("This channel isn't ignoring commands.");
         if (invites && !message.guild.settings.ignored.invites.includes(message.channel.id)) return message.error("This channel isn't ignoring invites.");
+        if (stars && !message.guild.settings.ignored.stars.includes(message.channel.id)) {
+            if (!message.guild.settings.starboard.id) return message.error("The starboard is not enabled.");
+            return message.error("This channel isn't ignoring stars.");
+        }
 
         const newArray = message.guild.settings.ignored[args[1]];
         newArray.splice(newArray.indexOf(message.channel.id), 1);

--- a/src/events/messageReactionAdd.js
+++ b/src/events/messageReactionAdd.js
@@ -13,6 +13,7 @@ class MessageReactionAdd extends Event {
         const settings = messageReaction.message.guild.settings = await messageReaction.message.guild.fetchSettings();
 
         if (!settings.starboard.id) return;
+        if (settings.ignored.stars.includes(messageReaction.message.channel.id)) return;
         if (messageReaction.count < settings.starboard.count) return;
         if (!messageReaction.message.guild.channels.has(settings.starboard.id)) return;
 

--- a/src/structures/Settings.js
+++ b/src/structures/Settings.js
@@ -12,7 +12,8 @@ module.exports = (id) => {
         },
         "ignored": {
             "commands": [],
-            "invites": []
+            "invites": [],
+            "stars": []
         },
         "announcements": {
             "id": null,


### PR DESCRIPTION
- Removes the minimum limitation and allows messages to be added to the starboard with as little as one star (if configured).
- Adds the ability to ignore stars in certain channels using the `$ignore` command.