### PR TITLE
Automatic Role for Bots

### DIFF
--- a/src/commands/moderation/settings.js
+++ b/src/commands/moderation/settings.js
@@ -9,8 +9,9 @@ const settingsList = {
     "muterole": "A role the bot will give users when muted.",
     "blacklistrole": "Users with this role will be denied access to any of TypicalBot's commands.",
     "autorole": "Users joining the server will automatically be given this role.",
-    "autoroledelay": "The amount of time to wait before giving the autorole to allow for security levels to work.",
-    "autorolesilent": "If not silent, a message will be sent in the logs channel stating a user was given the autorole.",
+    "autorole-bots": "Bots joining the server will automatically be given this role.",
+    "autorole-delay": "The amount of time to wait before giving the autorole to allow for security levels to work.",
+    "autorole-silent": "If not silent, a message will be sent in the logs channel stating a member was given the autorole.",
     "subscriberrole": "A role that will be given when a user uses the `subscribe` command.",
     "announcements": "A channel for announcements to be posted, used with the `announce` command.",
     "announcements-mention": "A mention to be put in the announcement when posted, such as a Subscriber role.",
@@ -122,9 +123,14 @@ module.exports = class extends Command {
 
                     if (!role) return message.reply(`**__Current Value:__** None`);
                     message.reply(`**__Current Value:__** ${role.name}`);
-                } else if (setting === "autoroledelay") {
+                } else if (setting === "autorole-bots") {
+                    const role = message.guild.roles.get(message.guild.settings.auto.role.bots);
+
+                    if (!role) return message.reply(`**__Current Value:__** None`);
+                    message.reply(`**__Current Value:__** ${role.name}`);
+                } else if (setting === "autorole-delay") {
                     message.reply(`**__Current Value:__** ${message.guild.settings.auto.role.delay ? `${message.guild.settings.auto.role.delay}ms` : "Default"}`);
-                } else if (setting === "autorolesilent") {
+                } else if (setting === "autorole-silent") {
                     message.reply(`**__Current Value:__** ${message.guild.settings.auto.role.silent ? "Enabled" : "Disabled"}`);
                 } else if (setting === "announcements") {
                     const channel = message.guild.channels.get(message.guild.settings.announcements.id);
@@ -427,7 +433,18 @@ module.exports = class extends Command {
 
                         this.client.settings.update(message.guild.id, { auto: { role: { id: role.id } } }).then(() => message.success("Setting successfully updated."));
                     }
-                } else if (setting === "autoroledelay") {
+                } else if (setting === "autorole-bots") {
+                    if (value === "disable") {
+                        this.client.settings.update(message.guild.id, { auto: { role: { bots: null } } }).then(() => message.success("Setting successfully updated."));
+                    } else {
+                        const subArgs = /(?:(?:<@&)?(\d{17,20})>?|(.+))/i.exec(value);
+
+                        const role = subArgs[1] ? message.guild.roles.get(subArgs[1]) : message.guild.roles.find(r => r.name.toLowerCase() === subArgs[2].toLowerCase());
+                        if (!role) return message.error("Invalid role. Please make sure your spelling is correct, and that the role actually exists.");
+
+                        this.client.settings.update(message.guild.id, { auto: { role: { bots: role.id } } }).then(() => message.success("Setting successfully updated."));
+                    }
+                } else if (setting === "autorole-delay") {
                     if (value === "disable" || value === "default") {
                         this.client.settings.update(message.guild.id, { auto: { role: { delay: null } } }).then(() => message.success("Setting successfully updated."));
                     } else {
@@ -436,7 +453,7 @@ module.exports = class extends Command {
 
                         this.client.settings.update(message.guild.id, { auto: { role: { delay: subArgs[1] } } }).then(() => message.success("Setting successfully updated."));
                     }
-                } else if (setting === "autorolesilent") {
+                } else if (setting === "autorole-silent") {
                     if (value === "disable") {
                         this.client.settings.update(message.guild.id, { auto: { role: { silent: false } } }).then(() => message.success("Setting successfully updated."));
                     } else if (value === "enable") {

--- a/src/events/guildMemberAdd.js
+++ b/src/events/guildMemberAdd.js
@@ -40,7 +40,14 @@ class GuildMemberAdd extends Event {
 
         if (settings.auto.nickname) member.setNickname(this.client.functions.formatMessage("autonick", guild, user, settings.auto.nickname)).catch(() => { return; });
 
-        const autorole = settings.auto.role.id ? guild.roles.has(settings.auto.role.id) ? guild.roles.get(settings.auto.role.id) : null : null;
+        let autorole;
+        if (settings.auto.role.bots && member.author.bot) {
+            autorole = settings.auto.role.bots ? guild.roles.has(settings.auto.role.bots) ? guild.roles.get(settings.auto.role.bots) : null : null;
+        }
+        else if (settings.auto.role.id) {
+            autorole = settings.auto.role.id ? guild.roles.has(settings.auto.role.id) ? guild.roles.get(settings.auto.role.id) : null : null;
+        }
+
         if (autorole && autorole.editable) setTimeout(() =>
             member.roles.add(autorole).then(() => {
                 if (settings.auto.role.silent === "N" && settings.logs.id && guild.channels.has(settings.logs.id)) guild.channels.get(settings.logs.id).send(`**${user.tag}** was given the autorole **${autorole.name}**.`);

--- a/src/events/guildMemberAdd.js
+++ b/src/events/guildMemberAdd.js
@@ -41,12 +41,10 @@ class GuildMemberAdd extends Event {
         if (settings.auto.nickname) member.setNickname(this.client.functions.formatMessage("autonick", guild, user, settings.auto.nickname)).catch(() => { return; });
 
         let autorole;
-        if (settings.auto.role.bots && member.user.bot) {
+        if (settings.auto.role.bots && member.user.bot)
             autorole = settings.auto.role.bots ? guild.roles.has(settings.auto.role.bots) ? guild.roles.get(settings.auto.role.bots) : null : null;
-        }
-        else if (settings.auto.role.id) {
+        else if (settings.auto.role.id)
             autorole = settings.auto.role.id ? guild.roles.has(settings.auto.role.id) ? guild.roles.get(settings.auto.role.id) : null : null;
-        }
 
         if (autorole && autorole.editable) setTimeout(() =>
             member.roles.add(autorole).then(() => {

--- a/src/events/guildMemberAdd.js
+++ b/src/events/guildMemberAdd.js
@@ -41,7 +41,7 @@ class GuildMemberAdd extends Event {
         if (settings.auto.nickname) member.setNickname(this.client.functions.formatMessage("autonick", guild, user, settings.auto.nickname)).catch(() => { return; });
 
         let autorole;
-        if (settings.auto.role.bots && member.author.bot) {
+        if (settings.auto.role.bots && member.user.bot) {
             autorole = settings.auto.role.bots ? guild.roles.has(settings.auto.role.bots) ? guild.roles.get(settings.auto.role.bots) : null : null;
         }
         else if (settings.auto.role.id) {

--- a/src/structures/Settings.js
+++ b/src/structures/Settings.js
@@ -33,6 +33,7 @@ module.exports = (id) => {
         },
         "auto": {
             "role": {
+                "bots": null,
                 "id": null,
                 "delay": null,
                 "silent": true


### PR DESCRIPTION
This PR introduces a couple of changes to automatic role related settings and introduces a new setting for adding a role to new bots when they join.

Added:

- `autorole-bots` for setting a role to add to bots when they join

Modified:

- `autoroledelay` is now `autorole-delay`
- `autorolesilent` is now `autorole-silent`