### PR TITLE
Add $dehoist command

### DIFF
--- a/src/commands/moderation/dehoist.js
+++ b/src/commands/moderation/dehoist.js
@@ -4,7 +4,7 @@ const Constants = require(`../../utility/Constants`);
 module.exports = class extends Command {
     constructor(...args) {
         super(...args, {
-            description: "Check if any members of the server has special characters in their username.",
+            description: "Check if any members of the server have any special characters in their username.",
             usage: "dehoist",
             permission: Constants.Permissions.Levels.SERVER_ADMINISTRATOR,
             mode: Constants.Modes.STRICT

--- a/src/commands/moderation/dehoist.js
+++ b/src/commands/moderation/dehoist.js
@@ -1,0 +1,21 @@
+const Command = require("../../structures/Command");
+const Constants = require(`../../utility/Constants`);
+
+module.exports = class extends Command {
+    constructor(...args) {
+        super(...args, {
+            description: "Check if any members of the server has special characters in their username.",
+            usage: "dehoist",
+            permission: Constants.Permissions.Levels.SERVER_ADMINISTRATOR,
+            mode: Constants.Modes.STRICT
+        });
+    }
+
+    execute(message, parameters, permissionLevel) {
+        const members = message.guild.members.filter(m => /^(!|"|#|\$|%|&|'|\(|\)|\*|\+|,|-|\.|\/|\[|\])$/.test(m.displayName.substring(0, 1)));
+
+        const list = members.map(m => `» ${m.displayName} (${m.id})`);
+
+        message.send(list.length ? `There ${list.length === 1 ? "is 1 user" : `are ${list.length} users`} that can be dehoisted:\n\n${list.join("\n").substring(0, 2000)}` : "There are no users that can be dehoisted.");
+    }
+}


### PR DESCRIPTION
## Pull Request

### Items Changed

- [X] Commands
- [ ] Events
- [ ] Handlers
- [ ] Structures
- [ ] Tasks
- [ ] Documentation
- [ ] Other: ______

### Description

<!-- Describe the changes you made. -->

Adds a new moderation command: `$dehoist`. As of right now, it currently works like `$adcheck`. A couple parameter ideas would be:
 - `@user` => dehoist a specific user
 - `all` => dehoist all users

### Issues

<!-- Does your pull request close/fix any issues reported? -->

### Have You...?

- [X] I have read the [Contributing Guidelines](https://github.com/typicalbot/typicalbot/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked current [pull requests](https://github.com/typicalbot/typicalbot/pulls) for upcoming features and fixes.
