### PR TITLE
Fix message showing modlogs-purge setting

### DIFF
--- a/src/commands/moderation/settings.js
+++ b/src/commands/moderation/settings.js
@@ -201,7 +201,7 @@ module.exports = class extends Command {
                     if (!channel) return message.reply(`**__Current Value:__** None`);
                     message.reply(`**__Current Value:__** ${channel.toString()}`);
                 } else if (setting === "modlogs-purge") {
-                    message.reply(`**__Current Value:__** ${message.guild.settings.prefix.default ? "Enabled" : "Disabled"}`);
+                    message.reply(`**__Current Value:__** ${message.guild.settings.logs.purge ? "Enabled" : "Disabled"}`);
                 } else if (setting === "automessage") {
                     message.reply(`**__Current Value:__** ${message.guild.settings.auto.message ? `\`\`\`txt\n${message.guild.settings.auto.message}\n\`\`\`` : "None"}`);
                 } else if (setting === "autonickname") {


### PR DESCRIPTION
## Pull Request

### Items Changed

- [x] Commands
- [ ] Events
- [ ] Handlers
- [ ] Structures
- [ ] Tasks
- [ ] Documentation
- [ ] Other: ______

### Description

**Fixed**

- Fix `settings` command so that when the `modlogs-purge` setting is viewed, it checks the correct setting

### Issues

N/A

### Have You...?

- [x] I have read the [Contributing Guidelines](https://github.com/typicalbot/typicalbot/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [pull request template](https://github.com/typicalbot/typicalbot/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
- [x] I have checked open [pull requests](https://github.com/typicalbot/typicalbot/pulls) for upcoming features and fixes.
