### PR TITLE
Fix config.json refs

### DIFF
--- a/packages/typicalbot/src/commands/core/stats.ts
+++ b/packages/typicalbot/src/commands/core/stats.ts
@@ -3,7 +3,6 @@ import { loadavg } from 'os';
 import Command from '../../structures/Command';
 import Constants from '../../utility/Constants';
 import { TypicalMessage } from '../../types/typicalbot';
-import * as config from '../../../../../config.json';
 
 export default class extends Command {
     dm = true;
@@ -43,7 +42,7 @@ export default class extends Command {
         if (!message.embedable)
             return message.send(
                 message.translate(
-                    config.clustered
+                    this.client.config.clustered
                         ? 'core/stats:CLUSTERED_TEXT'
                         : 'core/stats:TEXT',
                     {
@@ -131,7 +130,7 @@ export default class extends Command {
             .setFooter('TypicalBot', Constants.Links.ICON)
             .setTimestamp();
 
-        if (config.clustered)
+        if (this.client.config.clustered)
             embed
                 .addBlankField()
                 .addField('» Cluster', `${clusterName}\n${clusterShards}`, true)

--- a/packages/typicalbot/src/commands/system/restart.ts
+++ b/packages/typicalbot/src/commands/system/restart.ts
@@ -1,7 +1,6 @@
 import * as pm2 from 'pm2';
 import Command from '../../structures/Command';
 import Constants from '../../utility/Constants';
-import * as config from '../../../../../config.json';
 import { TypicalGuildMessage } from '../../types/typicalbot';
 
 export default class extends Command {
@@ -16,8 +15,10 @@ export default class extends Command {
 
             for (let i = 1; i <= Number(process.env.CLUSTER_COUNT); i++) {
                 list.push(
-                    `${config.clusterServer}-${
-                        config.clusterBuild ? `${config.clusterBuild}-` : ''
+                    `${this.client.config.clusterServer}-${
+                        this.client.config.clusterBuild
+                            ? `${this.client.config.clusterBuild}-`
+                            : ''
                     }${i}`
                 );
             }

--- a/packages/typicalbot/src/handlers/Database.ts
+++ b/packages/typicalbot/src/handlers/Database.ts
@@ -1,20 +1,21 @@
 import { r, MasterPool } from 'rethinkdb-ts';
-import { Client } from 'discord.js';
-import * as config from '../../../../config.json';
+import Cluster from '..';
 
 export default class DatabaseHandler {
     connection = r;
-    client: Client;
+    client: Cluster;
     pool: MasterPool | null = null;
 
-    constructor(client: Client) {
+    constructor(client: Cluster) {
         this.client = client;
 
         this.init();
     }
 
     async init() {
-        this.pool = await r.connectPool(config.database.credentials);
+        this.pool = await r.connectPool(
+            this.client.config.database.credentials
+        );
     }
 
     get(table: string, key?: string) {

--- a/packages/typicalbot/src/utility/Music.ts
+++ b/packages/typicalbot/src/utility/Music.ts
@@ -1,22 +1,22 @@
 import * as ytdl from 'ytdl-core';
 import * as YAPI from 'simple-youtube-api';
-import * as configs from '../../../../config.json';
 import Video from '../structures/Video';
 import Cluster from '../index.js';
 import { TypicalGuildMessage, GuildSettings } from '../types/typicalbot.js';
 import PermissionLevel from '../structures/PermissionLevel.js';
 import { Youtube } from 'simple-youtube-api';
 
-const apiKey = configs.apis.youtube;
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
-const TBYT = new YAPI(apiKey);
-
 export default class AudioUtil {
     client: Cluster;
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    TBYT: any;
+
     constructor(client: Cluster) {
         this.client = client;
+        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+        // @ts-ignore
+        this.TBYT = new YAPI(this.client.config.apis.youtube);
     }
 
     withinLimit(message: TypicalGuildMessage, video: Video) {
@@ -36,7 +36,7 @@ export default class AudioUtil {
             ? // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
               // @ts-ignore
               new YAPI(message.guild.settings.music.apikey)
-            : TBYT) as Youtube;
+            : this.TBYT) as Youtube;
 
         const playlist = await YT.getPlaylistByID(id);
         const videos = playlist ? await playlist.getVideos() : [];
@@ -49,7 +49,7 @@ export default class AudioUtil {
             ? // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
               // @ts-ignore
               new YAPI(settings.music.apikey)
-            : TBYT) as Youtube;
+            : this.TBYT) as Youtube;
 
         return YT.searchVideos(query, 10).catch(() => []);
     }


### PR DESCRIPTION
## Pull Request
This PR simply removes the importing of the config file directly and instead opts to use `this.client.config`

### Items Changed

- [x] Commands
- [ ] Events
- [ ] Handlers
- [x] Structures
- [ ] Tasks
- [ ] Documentation
- [ ] Other: ______

### Description

Remove importing of config.json in favor of using this.client.config.

### Issues

<!-- Does your pull request close/fix any issues reported? -->
Closes #96 

### Have You...?

- [x] I have read the [Contributing Guidelines](https://github.com/typicalbot/typicalbot/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [pull request template](https://github.com/typicalbot/typicalbot/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
- [x] I have checked open [pull requests](https://github.com/typicalbot/typicalbot/pulls) for upcoming features and fixes.
