### PR TITLE
update i18next dependency and remove airbnb

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,7 @@
 import { Client, ClientSocket, NodeMessage } from 'veza';
 import { TextChannel } from 'discord.js';
 import Cluster from './packages/typicalbot/src';
-import * as config from './config.json';
+import config from './config.json';
 
 if (!config.clustered) new Cluster(undefined);
 else {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "packages/*"
   ],
   "dependencies": {
+    "@types/ws": "^6.0.3",
     "discord.js": "github:discordjs/discord.js#master",
     "veza": "^1.1.0"
   },

--- a/packages/typicalbot-cluster/src/index.ts
+++ b/packages/typicalbot-cluster/src/index.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 import { Server } from 'veza';
-import * as config from '../config.json';
+import config from '../config.json';
 
 const regex = /\d+$/;
 

--- a/packages/typicalbot-cluster/tsconfig.json
+++ b/packages/typicalbot-cluster/tsconfig.json
@@ -1,39 +1,33 @@
 {
-	"compilerOptions": {
-		"alwaysStrict": true,
-		"declaration": false,
-		"emitDecoratorMetadata": true,
-		"experimentalDecorators": true,
-		"incremental": true,
-		"lib": [
-			"esnext"
-		],
-		"module": "commonjs",
-		"moduleResolution": "node",
-		"noEmitOnError": true,
-		"noImplicitAny": true,
-		"noImplicitReturns": true,
-		"noImplicitThis": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
-		"outDir": "../../production",
-		"pretty": true,
-		"removeComments": true,
-		"resolveJsonModule": true,
-		"sourceMap": true,
-		"strict": true,
-		"strictBindCallApply": true,
-		"strictNullChecks": true,
-		"strictPropertyInitialization": true,
-		"target": "esnext",
-		"types": [
-			"node"
-		],
-		"allowJs": false
-	},
-	"compileOnSave": true,
-	"include": [
-		"./src/**/*.ts",
-		"config.json"
-	]
+    "compilerOptions": {
+        "alwaysStrict": true,
+        "declaration": false,
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
+        "incremental": true,
+        "lib": ["esnext"],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "noEmitOnError": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "noImplicitThis": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "outDir": "../../production",
+        "pretty": true,
+        "removeComments": true,
+        "resolveJsonModule": true,
+        "sourceMap": true,
+        "strict": true,
+        "strictBindCallApply": true,
+        "strictNullChecks": true,
+        "strictPropertyInitialization": true,
+        "target": "esnext",
+        "types": ["node"],
+        "allowJs": false,
+        "esModuleInterop": true
+    },
+    "compileOnSave": true,
+    "include": ["./src/**/*.ts", "config.json"]
 }

--- a/packages/typicalbot/package.json
+++ b/packages/typicalbot/package.json
@@ -35,7 +35,7 @@
         "canvas-constructor": "^3.1.0",
         "discord.js": "github:discordjs/discord.js#master",
         "fs": "0.0.1-security",
-        "i18next": "^17.0.16",
+        "i18next": "^19.0.0",
         "i18next-node-fs-backend": "^2.1.3",
         "klaw": "^3.0.0",
         "mathjs": "^6.2.1",
@@ -72,8 +72,6 @@
         "esdoc-ecmascript-proposal-plugin": "^1.0.0",
         "esdoc-standard-plugin": "^1.0.0",
         "eslint": "^6.1.0",
-        "eslint-config-airbnb-base": "^14.0.0",
-        "eslint-config-airbnb-typescript": "^5.0.0",
         "eslint-config-typicalbot": "github:typicalbot/eslint-config-typicalbot",
         "eslint-plugin-import": "^2.18.2",
         "lerna": "^3.18.1"

--- a/packages/typicalbot/scripts/pm2.ts
+++ b/packages/typicalbot/scripts/pm2.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { Util } from 'discord.js';
-import * as pm2 from 'pm2';
-import * as config from '../../../config.json';
+import pm2 from 'pm2';
+import config from '../../../config.json';
 
 async function generateClusters() {
     const shardCount = await Util.fetchRecommendedShards(config.token);

--- a/packages/typicalbot/scripts/setup.ts
+++ b/packages/typicalbot/scripts/setup.ts
@@ -1,5 +1,5 @@
 import { r } from 'rethinkdb-ts';
-import * as configs from '../../../config.json';
+import configs from '../../../config.json';
 
 const { credentials } = configs.database;
 

--- a/packages/typicalbot/src/commands/fun/joke.ts
+++ b/packages/typicalbot/src/commands/fun/joke.ts
@@ -1,5 +1,5 @@
 import Command from '../../structures/Command';
-import * as jokes from '../../utility/jokes.json';
+import jokes from '../../utility/jokes.json';
 import { TypicalGuildMessage } from '../../types/typicalbot';
 
 export default class extends Command {

--- a/packages/typicalbot/src/commands/system/restart.ts
+++ b/packages/typicalbot/src/commands/system/restart.ts
@@ -1,4 +1,4 @@
-import * as pm2 from 'pm2';
+import pm2 from 'pm2';
 import Command from '../../structures/Command';
 import Constants from '../../utility/Constants';
 import { TypicalGuildMessage } from '../../types/typicalbot';

--- a/packages/typicalbot/src/commands/utility/calculator.ts
+++ b/packages/typicalbot/src/commands/utility/calculator.ts
@@ -1,4 +1,4 @@
-import * as math from 'mathjs';
+import math from 'mathjs';
 import Command from '../../structures/Command';
 import Constants from '../../utility/Constants';
 import { TypicalGuildMessage } from '../../types/typicalbot';

--- a/packages/typicalbot/src/commands/utility/serverinfo.ts
+++ b/packages/typicalbot/src/commands/utility/serverinfo.ts
@@ -1,5 +1,5 @@
 import { TypicalGuildMessage } from '../../types/typicalbot';
-import * as moment from 'moment';
+import moment from 'moment';
 import Command from '../../structures/Command';
 import Constants from '../../utility/Constants';
 import { MessageEmbed } from 'discord.js';

--- a/packages/typicalbot/src/commands/utility/userinfo.ts
+++ b/packages/typicalbot/src/commands/utility/userinfo.ts
@@ -1,4 +1,4 @@
-import * as moment from 'moment';
+import moment from 'moment';
 import Command from '../../structures/Command';
 import Constants from '../../utility/Constants';
 import { TypicalGuildMessage } from '../../types/typicalbot';

--- a/packages/typicalbot/src/events/messageDeleteBulk.ts
+++ b/packages/typicalbot/src/events/messageDeleteBulk.ts
@@ -1,4 +1,4 @@
-import * as moment from 'moment';
+import moment from 'moment';
 import fetch from 'node-fetch';
 import Event from '../structures/Event';
 import { Collection, TextChannel, MessageEmbed } from 'discord.js';

--- a/packages/typicalbot/src/functions/formatMessage.ts
+++ b/packages/typicalbot/src/functions/formatMessage.ts
@@ -1,4 +1,4 @@
-import * as moment from 'moment';
+import moment from 'moment';
 import Function from '../structures/Function';
 import { TypicalGuild, FormatMessageOptions } from '../types/typicalbot';
 import { User } from 'discord.js';

--- a/packages/typicalbot/src/handlers/Commands.ts
+++ b/packages/typicalbot/src/handlers/Commands.ts
@@ -1,6 +1,6 @@
 import { Collection } from 'discord.js';
 import { join, parse } from 'path';
-import * as klaw from 'klaw';
+import klaw from 'klaw';
 import Command from '../structures/Command';
 import Cluster from '..';
 import { GuildSettings } from '../types/typicalbot';

--- a/packages/typicalbot/src/handlers/Events.ts
+++ b/packages/typicalbot/src/handlers/Events.ts
@@ -1,5 +1,5 @@
 import { join, parse } from 'path';
-import * as klaw from 'klaw';
+import klaw from 'klaw';
 import { Collection } from 'discord.js';
 import Cluster from '..';
 import Event from '../structures/Event';

--- a/packages/typicalbot/src/handlers/Functions.ts
+++ b/packages/typicalbot/src/handlers/Functions.ts
@@ -1,5 +1,5 @@
 import { join, parse } from 'path';
-import * as klaw from 'klaw';
+import klaw from 'klaw';
 import { Collection } from 'discord.js';
 import Cluster from '..';
 import TypicalFunction from '../structures/Function';

--- a/packages/typicalbot/src/handlers/Permissions.ts
+++ b/packages/typicalbot/src/handlers/Permissions.ts
@@ -1,5 +1,5 @@
 import { join, parse } from 'path';
-import * as klaw from 'klaw';
+import klaw from 'klaw';
 import { Collection, Guild } from 'discord.js';
 import Cluster from '../index';
 import PermissionLevel from '../structures/PermissionLevel';

--- a/packages/typicalbot/src/handlers/Tasks.ts
+++ b/packages/typicalbot/src/handlers/Tasks.ts
@@ -1,6 +1,6 @@
 import { Collection } from 'discord.js';
 import { join, parse } from 'path';
-import * as klaw from 'klaw';
+import klaw from 'klaw';
 import Cluster from '../index';
 import { TaskOptions } from '../types/typicalbot';
 import Task from '../structures/Task';

--- a/packages/typicalbot/src/i18n.ts
+++ b/packages/typicalbot/src/i18n.ts
@@ -1,5 +1,5 @@
-import * as i18next from 'i18next';
-import * as Backend from 'i18next-node-fs-backend';
+import i18next, { TFunction } from 'i18next';
+import Backend from 'i18next-node-fs-backend';
 import * as path from 'path';
 import { promises as fs } from 'fs';
 
@@ -33,7 +33,7 @@ async function walkDirectory(
     return { namespaces: [...new Set(namespaces)], languages };
 }
 
-export default async (): Promise<Map<string, i18next.TFunction>> => {
+export default async (): Promise<Map<string, TFunction>> => {
     const options = {
         jsonIndent: 2,
         loadPath: path.resolve(

--- a/packages/typicalbot/src/index.ts
+++ b/packages/typicalbot/src/index.ts
@@ -5,7 +5,7 @@ import './extensions/TypicalMessage';
 import { Client, Collection } from 'discord.js';
 import fetch from 'node-fetch';
 import { Client as VezaClient } from 'veza';
-import * as config from '../../../config.json';
+import config from '../../../config.json';
 
 import DatabaseHandler from './handlers/Database';
 import TaskHandler from './handlers/Tasks';
@@ -25,7 +25,7 @@ import {
     UnbanLog
 } from './types/typicalbot';
 import i18n from '../src/i18n';
-import i18next = require('i18next');
+import { TFunction } from 'i18next';
 
 interface TypicalHandlers {
     database: DatabaseHandler;
@@ -57,7 +57,7 @@ export default class Cluster extends Client {
         softbans: new Collection(),
         invites: new Collection<string, Collection<string, NodeJS.Timeout>>()
     };
-    translate: Map<string, i18next.TFunction> = new Map();
+    translate: Map<string, TFunction> = new Map();
     constructor(node: VezaClient | undefined) {
         super({
             messageCacheMaxSize: 150,

--- a/packages/typicalbot/src/structures/Video.ts
+++ b/packages/typicalbot/src/structures/Video.ts
@@ -1,5 +1,5 @@
-import * as ytdl from 'ytdl-core';
-import * as SYS from 'simple-youtube-stream';
+import ytdl from 'ytdl-core';
+import SYS from 'simple-youtube-stream';
 import { TypicalGuildMessage } from '../types/typicalbot';
 
 const sys = new SYS();

--- a/packages/typicalbot/src/types/discord.d.ts
+++ b/packages/typicalbot/src/types/discord.d.ts
@@ -1,10 +1,10 @@
-import * as i18next from 'i18next';
 import Cluster from '..';
 import { GuildSettings } from './typicalbot';
+import { TFunction } from 'i18next';
 
 declare module 'discord.js' {
     interface Client {
-        translate: Map<string, i18next.TFunction>;
+        translate: Map<string, TFunction>;
     }
 
     interface Guild {

--- a/packages/typicalbot/src/utility/Music.ts
+++ b/packages/typicalbot/src/utility/Music.ts
@@ -1,5 +1,5 @@
-import * as ytdl from 'ytdl-core';
-import * as YAPI from 'simple-youtube-api';
+import ytdl from 'ytdl-core';
+import YAPI from 'simple-youtube-api';
 import Video from '../structures/Video';
 import Cluster from '../index.js';
 import { TypicalGuildMessage, GuildSettings } from '../types/typicalbot.js';

--- a/packages/typicalbot/tsconfig.json
+++ b/packages/typicalbot/tsconfig.json
@@ -5,9 +5,7 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "incremental": true,
-        "lib": [
-            "esnext"
-        ],
+        "lib": ["esnext"],
         "module": "commonjs",
         "moduleResolution": "node",
         "noEmitOnError": true,
@@ -26,14 +24,10 @@
         "strictNullChecks": true,
         "strictPropertyInitialization": true,
         "target": "esnext",
-        "types": [
-            "node"
-        ],
-        "allowJs": false
+        "types": ["node"],
+        "allowJs": false,
+        "esModuleInterop": true
     },
     "compileOnSave": true,
-    "include": [
-        "./**/*.ts",
-        "../../index.ts"
-    ]
+    "include": ["./**/*.ts", "../../index.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,9 +5,7 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "incremental": true,
-        "lib": [
-            "esnext"
-        ],
+        "lib": ["esnext"],
         "module": "commonjs",
         "moduleResolution": "node",
         "noEmitOnError": true,
@@ -26,13 +24,10 @@
         "strictNullChecks": true,
         "strictPropertyInitialization": true,
         "target": "esnext",
-        "types": [
-            "node"
-        ],
-        "allowJs": false
+        "types": ["node"],
+        "allowJs": false,
+        "esModuleInterop": true
     },
     "compileOnSave": true,
-    "include": [
-        "./**/*.ts"
-    ]
+    "include": ["./**/*.ts"]
 }


### PR DESCRIPTION
## Pull Request
As promised, this PR will update i18next and remove the eslint-airbnb.

Note: `"@types/ws": "^6.0.3",` was added because DJS requires it but is not installing it themself forcing us to install it in order to get the bot to run.

### Items Changed

- [ ] Commands
- [ ] Events
- [ ] Handlers
- [ ] Structures
- [ ] Tasks
- [ ] Documentation
- [ ] Other: ______

### Description

<!-- Describe the changes you made. -->
In order to update and handle the breaking changes made to i18next we needed to modify some settings across the entire tsconfigs. i18next went full support into import export which required enabling esModuleInterop. This option being enabled also broke other deps so all of those needed to be changed as well in the manner that they are imported. TFunction and other typings from i18next can now be directly imported.

### Issues

<!-- Does your pull request close/fix any issues reported? -->
Closes #99 
Closes #98 
### Have You...?

- [x] I have read the [Contributing Guidelines](https://github.com/typicalbot/typicalbot/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [pull request template](https://github.com/typicalbot/typicalbot/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
- [x] I have checked open [pull requests](https://github.com/typicalbot/typicalbot/pulls) for upcoming features and fixes.
