### PR TITLE
[3.x] fix: bots not mentioning users; sending success message on duplicate setting

### DIFF
--- a/src/commands/moderation/say.ts
+++ b/src/commands/moderation/say.ts
@@ -41,7 +41,7 @@ export default class extends Command {
             }
         } else {
             channel
-                .send(content, { disableMentions: true })
+                .send(content, { disableMentions: false })
                 .catch(() =>
                     message.error(
                         message.translate('moderation/say:MISSING_SEND')

--- a/src/extensions/TypicalMessage.ts
+++ b/src/extensions/TypicalMessage.ts
@@ -31,8 +31,27 @@ export class TypicalMessage extends Structures.get('Message') {
         embed?: MessageEmbed,
         options?: MessageOptions
     ) {
-        if (typeof content === 'string')
+        if (typeof content === 'string') {
+            content = (content || '').replace(/@(everyone|here)/g, '@\u200b$1');
+            const matches = content.match(/<@&(\d{17,19})>/g);
+            if (matches != null) {
+                matches.forEach(match => {
+                    match = match.replace('<@&', '').replace('>', '');
+
+                    if (this.guild && this.guild.roles.cache.has(match)) {
+                        match =
+                            '@\u200b' + this.guild.roles.cache.get(match)?.name;
+                    } else {
+                        match = '@\u200bdeleted-role';
+                    }
+                    content = (content as string).replace(
+                        /<@&(\d{17,19})>/,
+                        match
+                    );
+                });
+            }
             return this.channel.send(content, { ...options, embed });
+        }
         return this.channel.send(content);
     }
 

--- a/src/handlers/Settings.ts
+++ b/src/handlers/Settings.ts
@@ -40,7 +40,8 @@ export default class SettingHandler extends Collection<string, GuildSettings> {
             payload
         );
 
-        if (updated.changes) this.set(id, updated.changes[0].new_val);
+        if (updated.changes != undefined && updated.changes?.length > 0)
+            this.set(id, updated.changes[0].new_val);
 
         return true;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ export default class Cluster extends Client {
             messageCacheMaxSize: 150,
             messageCacheLifetime: 1800,
             messageSweepInterval: 300,
-            disableMentions: true,
+            disableMentions: false,
             disabledEvents: ['TYPING_START', 'CHANNEL_PINS_UPDATE'],
             partials: ['MESSAGE']
         });


### PR DESCRIPTION
## Pull Request

### Items Changed

- [ ] Commands
- [ ] Events
- [x] Handlers
- [ ] Structures
- [ ] Tasks
- [ ] Documentation
- [x] Other: Functions

### Description

<!-- Describe the changes you made. -->

####  Not sending success message on duplicate setting 
When editing a setting, setting a value 2 times will not send a correct response message, but silently error.

I fixed this by checking the length of the array instead of just comparing it using an if statement


#### fixing bots not mentioning users.

Because Discord.js removed disableEveryone and replaced it with disableMentions, normal user mentions are now also sanitized. I added it to the message.send extension. I also added it in the formatMessage function, because logs use a lot of user input.

### Issues
NA

### Have You...?

- [x] I have read the [Contributing Guidelines](https://github.com/typicalbot/typicalbot/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [pull request template](https://github.com/typicalbot/typicalbot/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
- [x] I have checked open [pull requests](https://github.com/typicalbot/typicalbot/pulls) for upcoming features and fixes.
