### PR TITLE
fix(i18n): user left message missing markdown

### DIFF
--- a/i18n/en-US/help/logs.json
+++ b/i18n/en-US/help/logs.json
@@ -43,7 +43,7 @@
     "WELCOME_ALERT": "**{{name}}'s Join Message:**",
     "AUTOROLE": "**{{user}}** was given the **{{role}}**.",
     "USER_LEFT": "User Left.",
-    "LEFT": "**{{user}} has left the server.",
+    "LEFT": "**{{user}}** has left the server.",
     "NICKNAMED": "**{{user}}** changed their nickname to **{{nickname}}**.",
     "CHANGED_NICK": "Changed nickname to {{nickname}}.",
     "DELETED": "**{{user}}**'s message was deleted.",


### PR DESCRIPTION
## Pull Request

### Items Changed

- [ ] Commands
- [ ] Events
- [ ] Handlers
- [ ] Structures
- [ ] Tasks
- [ ] Documentation
- [x] Other: i18n

### Description

Fixes an issue where some markdown is missing. The problem was only present in the en-US language.

### Issues

N/A

### Have You...?

- [x] I have read the [Contributing Guidelines](https://github.com/typicalbot/typicalbot/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [pull request template](https://github.com/typicalbot/typicalbot/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
- [x] I have checked open [pull requests](https://github.com/typicalbot/typicalbot/pulls) for upcoming features and fixes.
