### PR TITLE
fix: set presence in client options

### DIFF
--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,4 +1,3 @@
-import { ClientUser } from 'discord.js';
 import Event from '../structures/Event';
 
 export default class Ready extends Event {
@@ -6,7 +5,6 @@ export default class Ready extends Event {
 
     async execute() {
         this.client.logger.info(`Client Connected | Cluster ${this.client.cluster}`);
-        await (this.client.user as ClientUser).setActivity('Client is loading');
 
         setInterval(async () => {
             for (let i = 0; i < 50; i++) {
@@ -15,9 +13,5 @@ export default class Ready extends Event {
                 await this.client.analytics.publish();
             }
         }, 1000);
-
-        setTimeout(() =>
-            (this.client
-                .user as ClientUser).setActivity(`${this.client.config.prefix}help — typicalbot.com`, { type: 'WATCHING' }), 1000 * 60 * 5);
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,8 @@ export default class Cluster extends Client {
             messageCacheLifetime: 1800,
             messageSweepInterval: 300,
             disableMentions: 'everyone',
-            partials: ['MESSAGE']
+            partials: ['MESSAGE'],
+            presence: { activity: { name: `${config.prefix}help — typicalbot.com`, type: 'WATCHING' } }
         });
 
         Sentry.init({


### PR DESCRIPTION
## Pull Request

### Items Changed

- [ ] Commands
- [ ] Events
- [ ] Handlers
- [ ] Structures
- [ ] Tasks
- [ ] Documentation
- [x] Other: Client

### Description

Sets the presence in the client options instead of in the ready event.

### Issues

Closes #128 

### Have You...?

- [x] I have read the [Contributing Guidelines](https://github.com/typicalbot/typicalbot/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [pull request template](https://github.com/typicalbot/typicalbot/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
- [x] I have checked open [pull requests](https://github.com/typicalbot/typicalbot/pulls) for upcoming features and fixes.
