### PR TITLE
chore: update lint-staged config to run lint on committed files only

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     },
     "lint-staged": {
         "*.ts": [
-            "eslint . --ext .ts --fix"
+            "eslint --fix"
         ]
     },
     "commitlint": {


### PR DESCRIPTION
## Pull Request

### Items Changed

- [ ] Commands
- [ ] Events
- [ ] Handlers
- [ ] Structures
- [ ] Tasks
- [ ] Documentation
- [x] Other: package.json

### Description

Changes the lint-staged configuration so that only the committed files are linted instead of the entire project for each file. This should make linting faster when committing.

### Issues


### Have You...?

- [x] I have read the [Contributing Guidelines](https://github.com/typicalbot/typicalbot/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [pull request template](https://github.com/typicalbot/typicalbot/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
- [x] I have checked open [pull requests](https://github.com/typicalbot/typicalbot/pulls) for upcoming features and fixes.
