### PR TITLE
feat: change default value for `embed` setting

### DIFF
--- a/src/structures/Settings.ts
+++ b/src/structures/Settings.ts
@@ -4,7 +4,7 @@ export default (id: string) => ({
     dm: {
         commands: false
     },
-    embed: false,
+    embed: true,
     roles: {
         administrator: [],
         moderator: [],


### PR DESCRIPTION
## Pull Request

### Items Changed

- [ ] Commands
- [ ] Events
- [ ] Handlers
- [x] Structures
- [ ] Tasks
- [ ] Documentation
- [ ] Other: ______

### Description

Changes the `embed` setting value to be enabled by default, as that's generally the preferred behavior.

### Issues


### Have You...?

- [x] I have read the [Contributing Guidelines](https://github.com/typicalbot/typicalbot/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [pull request template](https://github.com/typicalbot/typicalbot/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
- [x] I have checked open [pull requests](https://github.com/typicalbot/typicalbot/pulls) for upcoming features and fixes.
