### PR TITLE
chore: remove api types - unused

### DIFF
--- a/src/types/apis.d.ts
+++ b/src/types/apis.d.ts
@@ -1,8 +1,0 @@
-export interface CarboniteBots {
-    name: string;
-    ownerid: string;
-    ownername: string;
-    botid: string;
-    compliant: number;
-    servercount: string;
-}


### PR DESCRIPTION
## Pull Request

### Items Changed

- [ ] Commands
- [ ] Events
- [ ] Handlers
- [ ] Structures
- [ ] Tasks
- [ ] Documentation
- [X] Other: typings

### Description

<!-- Describe the changes you made. -->
Removed api types (carbonitex) as they are no longer used

### Issues

<!-- Does your pull request close/fix any issues reported? -->

### Have You...?

- [X] I have read the [Contributing Guidelines](https://github.com/typicalbot/typicalbot/blob/master/.github/CONTRIBUTING.md).
- [X] I have completed the [pull request template](https://github.com/typicalbot/typicalbot/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
- [X] I have checked open [pull requests](https://github.com/typicalbot/typicalbot/pulls) for upcoming features and fixes.
