### PR TITLE
fix: `settings clear` responding with invalid usage

### DIFF
--- a/src/commands/administration/settings.ts
+++ b/src/commands/administration/settings.ts
@@ -2,7 +2,7 @@ import Command from '../../structures/Command';
 import { TypicalGuildMessage, SettingsData } from '../../types/typicalbot';
 import Constants from '../../utility/Constants';
 
-const regex = /(list|view|edit)(?:\s+([\w-]+)\s*(?:(add|remove)\s+)?((?:.|[\r\n])+)?)?/i;
+const regex = /(list|view|edit|clear)(?:\s+([\w-]+)\s*(?:(add|remove)\s+)?((?:.|[\r\n])+)?)?/i;
 const roleRegex = /(?:(?:<@&)?(\d{17,20})>?|(.+))/i;
 const msRegex = /^(\d+)$/i;
 const channelRegex = /(?:(?:<#)?(\d{17,20})>?|(.+))/i;


### PR DESCRIPTION
## Pull Request

### Items Changed

- [x] Commands
- [ ] Events
- [ ] Handlers
- [ ] Structures
- [ ] Tasks
- [ ] Documentation
- [ ] Other: ______

### Description

Fixes `$settings clear` responding with invalid usage.

### Issues

Fixes #174 

### Have You...?

- [x] I have read the [Contributing Guidelines](https://github.com/typicalbot/typicalbot/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [pull request template](https://github.com/typicalbot/typicalbot/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
- [x] I have checked open [pull requests](https://github.com/typicalbot/typicalbot/pulls) for upcoming features and fixes.
