### PR TITLE
handle potential undefined settings

### DIFF
--- a/src/extensions/TypicalGuild.ts
+++ b/src/extensions/TypicalGuild.ts
@@ -14,7 +14,7 @@ export class TypicalGuild extends Structures.get('Guild') {
     }
 
     translate(key: string, args?: object) {
-        const language = this.client.translate.get(typeof this.settings.language === 'undefined' ? 'en-US' : this.settings.language);
+        const language = this.client.translate.get(this.settings?.language || 'en-US');
 
         if (!language) throw 'Guild: Invalid language set in settings.';
 


### PR DESCRIPTION
## Pull Request
There was a small error trying to use settings.language when settings was undefined inside the typeof section `typeof this.settings.language`. If this.settings is undefined for whatever reason this throws an error trying to check .language on undefined.

A simple fix was to just use new TS features to say
```ts
this.settings?.language || 'en-US'
```
This will use the language if this.settings exists. If it does not exist, it should default to en-US going forward.

### Items Changed

- [ ] Commands
- [ ] Events
- [ ] Handlers
- [ ] Structures
- [ ] Tasks
- [ ] Documentation
- [x] Other: Extensions

### Description

<!-- Describe the changes you made. -->
Fixes 
![image](https://user-images.githubusercontent.com/23035000/80116758-594a2580-8554-11ea-8918-7c2f9aecefdc.png)

### Issues

<!-- Does your pull request close/fix any issues reported? -->
N/A

### Have You...?

- [x] I have read the [Contributing Guidelines](https://github.com/typicalbot/typicalbot/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [pull request template](https://github.com/typicalbot/typicalbot/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
- [x] I have checked open [pull requests](https://github.com/typicalbot/typicalbot/pulls) for upcoming features and fixes.
