### PR TITLE
Update purge.ts

### DIFF
--- a/src/commands/moderation/purge.ts
+++ b/src/commands/moderation/purge.ts
@@ -44,9 +44,8 @@ export default class extends Command {
         });
 
         messages = messages.filter((msg) => {
-            if (!msg.member) return false;
             if ([userMention, userID].includes(msg.author.id)) return true;
-            if (msg.member.roles.cache.has(roleID)) return true;
+            if (msg.member?.roles.cache.has(roleID)) return true;
             if (filter === 'me' && msg.author.id === message.author.id)
                 return true;
             if (filter === 'you' && msg.author.id === this.client.config.id)


### PR DESCRIPTION
## Pull Request

### Items Changed

- [x] Commands
- [ ] Events
- [ ] Handlers
- [ ] Structures
- [ ] Tasks
- [ ] Documentation
- [ ] Other: ______

### Description

<!-- Describe the changes you made. -->
This PR makes it so the purge command no longer requires a message.member in order to be removed. Instead message.member will be checked only when necessary.


### Issues

<!-- Does your pull request close/fix any issues reported? -->
Closes #180 -  In regards to the part of making a subcommand, I believe the `bots` filter will also cover any webhook messages and should be enough. Is there even a method to tell if a message is a webhook?

### Have You...?

- [x] I have read the [Contributing Guidelines](https://github.com/typicalbot/typicalbot/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [pull request template](https://github.com/typicalbot/typicalbot/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
- [x] I have checked open [pull requests](https://github.com/typicalbot/typicalbot/pulls) for upcoming features and fixes.
