### PR TITLE
fix: `randomuser` command to pick user by role

### DIFF
--- a/src/commands/utility/randomuser.ts
+++ b/src/commands/utility/randomuser.ts
@@ -10,10 +10,11 @@ export default class extends Command {
 
     execute(message: TypicalGuildMessage, parameters: string) {
         const args = regex.exec(parameters);
+        const role = parameters ? message.guild.roles.cache.get(parameters) || message.guild.roles.cache.find((role) => role.name.toLowerCase() === parameters.toLowerCase()) : message.mentions.roles.first()
 
         const members = args
             ? message.guild.members.cache.filter((m) => m.presence.status !== 'offline' && !m.user.bot)
-            : message.guild.members.cache.filter((m) => !m.user.bot);
+            : role ? role.members.filter((m) => !m.user.bot) : message.guild.members.cache.filter((m) => !m.user.bot);
         if (!members.size) return null;
 
         const member = members.random();


### PR DESCRIPTION
## Pull Request

### Items Changed

- [x] Commands
- [ ] Events
- [ ] Handlers
- [ ] Structures
- [ ] Tasks
- [ ] Documentation
- [ ] Other: ______

### Description

<!-- Describe the changes you made. -->
This PR adds a small bit of functionality to the randomuser command. If a role is provided in the form of a mention, id, or a role name, it will pick a member from that role.
### Issues

Closes #195 

### Have You...?

- [x] I have read the [Contributing Guidelines](https://github.com/typicalbot/typicalbot/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [pull request template](https://github.com/typicalbot/typicalbot/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
- [x] I have checked open [pull requests](https://github.com/typicalbot/typicalbot/pulls) for upcoming features and fixes.
