### PR TITLE
fix: `randomuser` role filter not working

### DIFF
--- a/src/commands/utility/randomuser.ts
+++ b/src/commands/utility/randomuser.ts
@@ -12,10 +12,11 @@ export default class extends Command {
         const args = regex.exec(parameters);
         const role = parameters ? message.guild.roles.cache.get(parameters) || message.guild.roles.cache.find((role) => role.name.toLowerCase() === parameters.toLowerCase()) : message.mentions.roles.first()
 
-        const members = args
-            ? message.guild.members.cache.filter((m) => m.presence.status !== 'offline' && !m.user.bot)
-            : role ? role.members.filter((m) => !m.user.bot) : message.guild.members.cache.filter((m) => !m.user.bot);
-        if (!members.size) return null;
+        const members = role
+            ? role.members.filter((m) => !m.user.bot)
+            : args
+                ? message.guild.members.cache.filter((m) => m.presence.status !== 'offline' && !m.user.bot)
+                : message.guild.members.cache.filter((m) => !m.user.bot);
 
         const member = members.random();
 


### PR DESCRIPTION
## Pull Request

### Items Changed

- [x] Commands
- [ ] Events
- [ ] Handlers
- [ ] Structures
- [ ] Tasks
- [ ] Documentation
- [ ] Other: ______

### Description

__Fixed__
- `randomuser` command role filter not working

### Issues


### Have You...?

- [x] I have read the [Contributing Guidelines](https://github.com/typicalbot/typicalbot/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [pull request template](https://github.com/typicalbot/typicalbot/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
- [x] I have checked open [pull requests](https://github.com/typicalbot/typicalbot/pulls) for upcoming features and fixes.
