### PR TITLE
fix: check ban members permission before fetching

### DIFF
--- a/src/events/guildMemberRemove.ts
+++ b/src/events/guildMemberRemove.ts
@@ -8,6 +8,7 @@ export default class GuildMemberRemove extends Event {
         if (!member.guild.available) return;
 
         const guild = member.guild as TypicalGuild;
+        if (!guild.me?.permissions.has('BAN_MEMBERS')) return;
 
         const bans = await guild.fetchBans().catch(() => null);
         if (bans && bans.has(member.id)) return;

--- a/src/events/guildMemberRemove.ts
+++ b/src/events/guildMemberRemove.ts
@@ -8,10 +8,12 @@ export default class GuildMemberRemove extends Event {
         if (!member.guild.available) return;
 
         const guild = member.guild as TypicalGuild;
-        if (!guild.me?.permissions.has('BAN_MEMBERS')) return;
+        // If bot has ban perms check if this was a ban and if so cancel out
+        if (guild.me?.permissions.has('BAN_MEMBERS')) {
+            const bans = await guild.fetchBans().catch(() => null);
+            if (bans && bans.has(member.id)) return;
+        }
 
-        const bans = await guild.fetchBans().catch(() => null);
-        if (bans && bans.has(member.id)) return;
 
         const settings = await this.client.settings.fetch(guild.id);
         if (!settings.logs.id || settings.logs.leave === '--disabled') return;


### PR DESCRIPTION
## Pull Request

### Items Changed

- [ ] Commands
- [x] Events
- [ ] Handlers
- [ ] Structures
- [ ] Tasks
- [ ] Documentation
- [ ] Other: ______

### Description

<!-- Describe the changes you made. -->
This PR should fix an error that happens when the guild does not give the bot BAN_MEMBERS permission. 
![image](https://user-images.githubusercontent.com/23035000/81424095-64d84780-9123-11ea-9aad-d67fd2fca311.png)

### Issues

<!-- Does your pull request close/fix any issues reported? -->

### Have You...?

- [ ] I have read the [Contributing Guidelines](https://github.com/typicalbot/typicalbot/blob/master/.github/CONTRIBUTING.md).
- [ ] I have completed the [pull request template](https://github.com/typicalbot/typicalbot/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
- [ ] I have checked open [pull requests](https://github.com/typicalbot/typicalbot/pulls) for upcoming features and fixes.
