### PR TITLE
fix: `twitch` response embed empty value

### DIFF
--- a/src/commands/utility/twitch.ts
+++ b/src/commands/utility/twitch.ts
@@ -3,20 +3,9 @@ import fetch from 'node-fetch';
 import Command from '../../lib/structures/Command';
 import { TypicalGuildMessage } from '../../lib/types/typicalbot';
 
-const regex = /(.*)/gi;
-
 export default class extends Command {
     async execute(message: TypicalGuildMessage, parameters: string) {
-        const args = regex.exec(parameters);
-        if (!args)
-            return message.error(message.translate('misc:USAGE_ERROR', {
-                name: this.name,
-                prefix: this.client.config.prefix
-            }));
-        args.shift();
-        const [name] = args;
-
-        const json = await fetch(`https://api.twitch.tv/helix/users?login=${name}`, {
+        const json = await fetch(`https://api.twitch.tv/helix/users?login=${parameters}`, {
             method: 'get',
             headers: { 'Client-ID': this.client.config.apis.twitch }
         })

--- a/src/commands/utility/twitch.ts
+++ b/src/commands/utility/twitch.ts
@@ -52,6 +52,8 @@ export default class extends Command {
                 '```'
             ].join('\n'));
 
+        const NA = message.translate('common:NA');
+
         return message.send(new MessageEmbed()
             .setColor(0x00adff)
             .setTitle('Twitch Statistics')
@@ -59,22 +61,22 @@ export default class extends Command {
             .addFields([
                 {
                     name: message.translate('common:ID_FIELD'),
-                    value: data.id,
+                    value: data.id || NA,
                     inline: true
                 },
                 {
                     name: message.translate('common:DISPLAYNAME_FIELD'),
-                    value: data.display_name,
+                    value: data.display_name || NA,
                     inline: true
                 },
                 {
                     name: message.translate('common:STATUS_FIELD'),
-                    value: data.broadcaster_type,
+                    value: data.broadcaster_type || NA,
                     inline: true
                 },
                 {
                     name: message.translate('common:TOTALVIEWS'),
-                    value: data.view_count,
+                    value: data.view_count || NA,
                     inline: true
                 }
             ])

--- a/src/commands/utility/twitch.ts
+++ b/src/commands/utility/twitch.ts
@@ -23,7 +23,7 @@ export default class extends Command {
             .then((res) => res.json())
             .catch(() => null);
 
-        if (!json || !json.data)
+        if (!json || !json.data?.length)
             return message.error(message.translate('common:REQUEST_ERROR'));
 
         const data = json.data[0];

--- a/src/commands/utility/twitch.ts
+++ b/src/commands/utility/twitch.ts
@@ -15,7 +15,7 @@ export default class extends Command {
         if (!json || !json.data?.length)
             return message.error(message.translate('common:REQUEST_ERROR'));
 
-        const data = json.data[0];
+        const [data] = json.data;
         if (!message.embeddable)
             return message.reply([
                 message.translate('utility/twitch:STATS', {

--- a/src/commands/utility/twitch.ts
+++ b/src/commands/utility/twitch.ts
@@ -5,6 +5,12 @@ import { TypicalGuildMessage } from '../../lib/types/typicalbot';
 
 export default class extends Command {
     async execute(message: TypicalGuildMessage, parameters: string) {
+        if (!parameters)
+            return message.error(message.translate('misc:USAGE_ERROR', {
+                name: this.name,
+                prefix: this.client.config.prefix
+            }));
+
         const json = await fetch(`https://api.twitch.tv/helix/users?login=${parameters}`, {
             method: 'get',
             headers: { 'Client-ID': this.client.config.apis.twitch }


### PR DESCRIPTION
## Pull Request

### Items Changed

- [x] Commands
- [ ] Events
- [ ] Handlers
- [ ] Structures
- [ ] Tasks
- [ ] Documentation
- [ ] Other: ______

### Description

<!-- Describe the changes you made. -->
This should fix some errors related to the Twitch command. Atm sometimes the embed was unable to be sent because the value in the embed field was empty.

This should also fix when the data is empty.

### Issues

<!-- Does your pull request close/fix any issues reported? -->

### Have You...?

- [x] I have read the [Contributing Guidelines](https://github.com/typicalbot/typicalbot/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [pull request template](https://github.com/typicalbot/typicalbot/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
- [x] I have checked open [pull requests](https://github.com/typicalbot/typicalbot/pulls) for upcoming features and fixes.
