### PR TITLE
fix: i18n problem and non-existent page access information, fixes #211 and #212

### DIFF
--- a/etc/languages/en-US/administration/settings.json
+++ b/etc/languages/en-US/administration/settings.json
@@ -1,6 +1,7 @@
 {
     "DESCRIPTION": "View or customize your servers setting and enable/disable specific features.",
     "USAGE": "settings <list|clear|view|edit> [setting] [add|remove] [value]",
+    "USAGE_LIST": "Use `{{prefix}}settings list [page]` to view other pages.",
     "AVAILABLE": "**__Available settings to use with TypicalBot:__**",
     "PAGE": "**Page {{page}} / {{count}}**",
     "CLEARED": "Settings cleared.",

--- a/etc/languages/en-US/administration/settings.json
+++ b/etc/languages/en-US/administration/settings.json
@@ -51,7 +51,7 @@
     "ANTIINVITE-ACTION": "Enable warning and kicking when sending invites. AntiInvite must be enabled for this to work.",
     "ANTIINVITE-WARN": "A user will receive a warning if they send this exact number of invites. AntiInvite and AntiInvite Action must be enabled for this to work.",
     "ANTIINVITE-KICK": "A user will be kicked if they send this number or more invites. AntiInvite and AntiInvite Action must be enabled for this to work.",
-    "NONNICKNAME": "A way to disable the `nickname` command from being used.",
+    "NONICKNAME": "A way to disable the `nickname` command from being used.",
     "STARBOARD": "A channel to send starred messages in, i.e. a starboard.",
     "STARBOARD-STARS": "Change the required stars count for messages to appear in the starboard.",
     "LANGUAGE": "Change the language of the bot in your server."

--- a/src/commands/administration/settings.ts
+++ b/src/commands/administration/settings.ts
@@ -369,7 +369,8 @@ export default class extends Command {
             message.translate('administration/settings:AVAILABLE'),
             '',
             message.translate('administration/settings:PAGE', { page, count }),
-            list.join('\n')
+            list.join('\n'),
+            message.translate('administration/settings:USAGE_LIST')
         ].join('\n'));
     }
 

--- a/src/commands/administration/settings.ts
+++ b/src/commands/administration/settings.ts
@@ -345,7 +345,6 @@ export default class extends Command {
                 const type = settingsData[k].type
                 const value = settingsData[k].value
 
-                console.log(k, type, value)
                 if (type === 'channel') {
                     if (value && message.guild.channels.cache.has(value)) response += `<#${value}>`
                     else response += NA

--- a/src/commands/administration/settings.ts
+++ b/src/commands/administration/settings.ts
@@ -370,6 +370,7 @@ export default class extends Command {
             '',
             message.translate('administration/settings:PAGE', { page, count }),
             list.join('\n'),
+            '',
             message.translate('administration/settings:USAGE_LIST', { prefix: this.client.config.prefix })
         ].join('\n'));
     }

--- a/src/commands/administration/settings.ts
+++ b/src/commands/administration/settings.ts
@@ -370,7 +370,7 @@ export default class extends Command {
             '',
             message.translate('administration/settings:PAGE', { page, count }),
             list.join('\n'),
-            message.translate('administration/settings:USAGE_LIST')
+            message.translate('administration/settings:USAGE_LIST', { prefix: this.client.config.prefix })
         ].join('\n'));
     }
 

--- a/src/commands/administration/settings.ts
+++ b/src/commands/administration/settings.ts
@@ -291,7 +291,7 @@ export default class extends Command {
                         path: 'starboard.id'
                     },
                     'starboard-stars': {
-                        description: 'administration/settings: STARBOARD-STARS',
+                        description: 'administration/settings:STARBOARD-STARS',
                         value: settings.starboard.count,
                         type: 'default',
                         path: 'starboard.count'

--- a/src/commands/administration/settings.ts
+++ b/src/commands/administration/settings.ts
@@ -341,28 +341,28 @@ export default class extends Command {
             .map((k) => {
                 if (!view) return `• **${k}:** ${message.translate(settingsData[k].description)}`;
 
-                let response = ` • **${k}:** `
-                const type = settingsData[k].type
-                const value = settingsData[k].value
+                let response = ` • **${k}:** `;
+                const type = settingsData[k].type;
+                const value = settingsData[k].value;
 
                 if (type === 'channel') {
-                    if (value && message.guild.channels.cache.has(value)) response += `<#${value}>`
-                    else response += NA
+                    if (value && message.guild.channels.cache.has(value)) response += `<#${value}>`;
+                    else response += NA;
                 } else if (type === 'channels') {
-                    if (value.length) response += value.map((id: string) => `<#${id}>`)
-                    else response += NA
+                    if (value.length) response += value.map((id: string) => `<#${id}>`);
+                    else response += NA;
                 } else if (type === 'role') {
-                    const role = message.guild.roles.cache.get(value)
-                    if (role) response += role.name
-                    else response += NA
+                    const role = message.guild.roles.cache.get(value);
+                    if (role) response += role.name;
+                    else response += NA;
                 } else if (type === 'roles') {
-                    if (value.length) response += value.map((id: string) => message.guild.roles.cache.get(id)?.name || 'Unknown Role').join(', ')
-                    else response += NA
-                } else if (type === 'boolean') response += message.translate(value ? 'common:ENABLED' : 'common:DISABLED')
-                else if (type === 'log' && value === '--embed') response += 'Embed'
-                else response += value || NA
+                    if (value.length) response += value.map((id: string) => message.guild.roles.cache.get(id)?.name || 'Unknown Role').join(', ');
+                    else response += NA;
+                } else if (type === 'boolean') response += message.translate(value ? 'common:ENABLED' : 'common:DISABLED');
+                else if (type === 'log' && value === '--embed') response += 'Embed';
+                else response += value || NA;
 
-                return response
+                return response;
             });
 
         return message.send([

--- a/src/commands/administration/settings.ts
+++ b/src/commands/administration/settings.ts
@@ -339,7 +339,7 @@ export default class extends Command {
         const list = settings
             .splice((page - 1) * 10, 10)
             .map((k) => {
-                if (!view) return message.translate(settingsData[k].description)
+                if (!view) return `• **${k}:** ${message.translate(settingsData[k].description)}`;
 
                 let response = ` • **${k}:** `
                 const type = settingsData[k].type


### PR DESCRIPTION
## Pull Request

### Items Changed

- [x] Commands
- [ ] Events
- [ ] Handlers
- [ ] Structures
- [ ] Tasks
- [ ] Documentation
- [x] Other: Languages

### Description

__Added__
- Page access information in `settings` command (#212)

__Fixed__
- `settings` command i18n problem (#211)
- `settings` command list response

### Issues

Fixes #211 
Fixes #212 

### Have You...?

- [x] I have read the [Contributing Guidelines](https://github.com/typicalbot/typicalbot/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [pull request template](https://github.com/typicalbot/typicalbot/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
- [x] I have checked open [pull requests](https://github.com/typicalbot/typicalbot/pulls) for upcoming features and fixes.
