### PR TITLE
feat: sync autorole

### DIFF
--- a/etc/languages/en-US/administration/settings.json
+++ b/etc/languages/en-US/administration/settings.json
@@ -30,6 +30,7 @@
     "AUTOROLE-BOTS": "Bots joining the server will automatically be given this role.",
     "AUTOROLE-DELAY": "The amount of time to wait before giving the autorole to allow for security levels to work.",
     "AUTOROLE-SILENT": "If not silent, a message will be sent in the logs channel stating a member was given the autorole.",
+    "AUTOROLE-SYNC": "If sync is enabled, the bot will always try and provide the autorole whenever it reboots after an update or API crash.",
     "SUBSCRIBERROLE": "A role that will be given when a user uses the `subscribe` command.",
     "ANNOUNCEMENTS": "A channel for announcements to be posted, used with the `announce` command.",
     "ANNOUNCEMENTS-MENTION": "A mention to be put in the announcement when posted, such as a Subscriber role.",

--- a/etc/languages/en-US/administration/settings.json
+++ b/etc/languages/en-US/administration/settings.json
@@ -30,7 +30,7 @@
     "AUTOROLE-BOTS": "Bots joining the server will automatically be given this role.",
     "AUTOROLE-DELAY": "The amount of time to wait before giving the autorole to allow for security levels to work.",
     "AUTOROLE-SILENT": "If not silent, a message will be sent in the logs channel stating a member was given the autorole.",
-    "AUTOROLE-SYNC": "If sync is enabled, the bot will always try and provide the autorole whenever it reboots after an update or API crash.",
+    "AUTOROLE-SYNC": "When enabled, the configured autorole will be added to members that don't have it when the bot is rebooted.",
     "SUBSCRIBERROLE": "A role that will be given when a user uses the `subscribe` command.",
     "ANNOUNCEMENTS": "A channel for announcements to be posted, used with the `announce` command.",
     "ANNOUNCEMENTS-MENTION": "A mention to be put in the announcement when posted, such as a Subscriber role.",

--- a/src/commands/administration/settings.ts
+++ b/src/commands/administration/settings.ts
@@ -151,6 +151,12 @@ export default class extends Command {
                         type: 'boolean',
                         path: 'auto.role.silent'
                     },
+                    'autorole-sync': {
+                        description: 'administration/settings:AUTOROLE-SYNC',
+                        value: settings.auto.role.sync,
+                        type: 'boolean',
+                        path: 'auto.role.sync'
+                    },
                     announcements: {
                         description: 'administration/settings:ANNOUNCEMENTS',
                         value: settings.announcements.id,

--- a/src/events/guildMemberAdd.ts
+++ b/src/events/guildMemberAdd.ts
@@ -54,32 +54,6 @@ export default class GuildMemberAdd extends Event {
                 .setNickname(await this.client.helpers.formatMessage.execute('autonick', guild, user, settings.auto.nickname))
                 .catch((err) => Sentry.captureException(err));
 
-        const autorole =
-            settings.auto.role.bots && member.user.bot
-                ? guild.roles.cache.get(settings.auto.role.bots)
-                : settings.auto.role.id
-                    ? guild.roles.cache.get(settings.auto.role.id)
-                    : null;
-        if (!autorole || !autorole.editable) return;
-
-        if (guild.verificationLevel !== 'VERY_HIGH') {
-            setTimeout(async () => {
-                const added = await member.roles
-                    .add(autorole.id)
-                    .catch((err) => Sentry.captureException(err));
-
-                if (settings.auto.role.silent) return null;
-
-                if (!added || !settings.logs.id) return null;
-
-                const channel = guild.channels.cache.get(settings.logs.id) as TextChannel;
-                if (!channel || channel.type !== 'text') return null;
-
-                return channel.send(guild.translate('help/logs:AUTOROLE', {
-                    user: user.tag,
-                    role: autorole.name
-                }));
-            }, guild.verificationLevel === 'HIGH' ? 60000 : settings.auto.role.delay || 2000);
-        }
+        this.client.handlers.moderationLog.grantAutoRole(member, settings)
     }
 }

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -25,5 +25,7 @@ export default class Ready extends Event {
                 await this.client.analytics.publish();
             }
         }, 1000);
+
+        this.client.handlers.moderationLog.processAutoRoles()
     }
 }

--- a/src/handlers/ModerationLogHandler.ts
+++ b/src/handlers/ModerationLogHandler.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/node';
-import { Guild, GuildMember, TextChannel, User, Role } from 'discord.js';
+import { Guild, GuildMember, TextChannel, User } from 'discord.js';
 import Cluster from '../lib/TypicalClient';
 import ModerationLog from '../lib/structures/ModerationLog';
 import { TypicalGuildMessage , TypicalGuild, GuildSettings } from '../lib/types/typicalbot';

--- a/src/handlers/ModerationLogHandler.ts
+++ b/src/handlers/ModerationLogHandler.ts
@@ -1,7 +1,8 @@
-import { Guild, TextChannel, User } from 'discord.js';
+import * as Sentry from '@sentry/node';
+import { Guild, GuildMember, TextChannel, User, Role } from 'discord.js';
 import Cluster from '../lib/TypicalClient';
 import ModerationLog from '../lib/structures/ModerationLog';
-import { TypicalGuildMessage , TypicalGuild } from '../lib/types/typicalbot';
+import { TypicalGuildMessage , TypicalGuild, GuildSettings } from '../lib/types/typicalbot';
 
 export default class ModerationLogHandler {
     client: Cluster;
@@ -73,5 +74,44 @@ export default class ModerationLogHandler {
                     reason
                 })
             ]));
+    }
+
+    processAutoRoles() {
+        this.client.guilds.cache.forEach(async (guild) => {
+            const settings = await this.client.settings.fetch(guild.id);
+            if (!settings.auto.role.sync || (!settings.auto.role.bots && !settings.auto.role.id)) return;
+
+            guild.members.cache.forEach((member) => this.grantAutoRole(member, settings))
+        })
+
+    }
+
+    grantAutoRole(member: GuildMember, settings: GuildSettings) {
+        const autorole =
+            settings.auto.role.bots && member.user.bot
+                ? member.guild.roles.cache.get(settings.auto.role.bots)
+                : settings.auto.role.id
+                    ? member.guild.roles.cache.get(settings.auto.role.id)
+                    : undefined;
+        if (!autorole || !autorole.editable || member.roles.cache.has(autorole.id) || member.guild.verificationLevel === 'VERY_HIGH') return;
+
+
+        setTimeout(async () => {
+            const added = await member.roles
+                .add(autorole.id)
+                .catch((err) => Sentry.captureException(err));
+
+            if (settings.auto.role.silent) return;
+
+            if (!added || !settings.logs.id) return;
+
+            const channel = member.guild.channels.cache.get(settings.logs.id) as TextChannel;
+            if (!channel || channel.type !== 'text') return;
+
+            return channel.send((member.guild as TypicalGuild).translate('help/logs:AUTOROLE', {
+                user: member.user.tag,
+                role: autorole.name
+            }));
+        }, member.guild.verificationLevel === 'HIGH' ? 60000 : settings.auto.role.delay || 2000);
     }
 }

--- a/src/lib/structures/Settings.ts
+++ b/src/lib/structures/Settings.ts
@@ -40,7 +40,8 @@ export default (id: string) => ({
             bots: null,
             id: null,
             delay: null,
-            silent: true
+            silent: true,
+            sync: true
         },
         message: null,
         nickname: null

--- a/src/lib/types/typicalbot.d.ts
+++ b/src/lib/types/typicalbot.d.ts
@@ -68,6 +68,7 @@ export interface GuildSettings {
             id: string | null;
             delay: number | null;
             silent: boolean;
+            sync: boolean;
         };
         message: string | null;
         nickname: string | null;


### PR DESCRIPTION
## Pull Request

### Items Changed

- [ ] Commands
- [x] Events
- [x] Handlers
- [ ] Structures
- [ ] Tasks
- [ ] Documentation
- [x] Other: setting `auto.role.sync`

### Description

<!-- Describe the changes you made. -->
This PR should allow the autorole to be assigned whenever the bot restarts on all users. A new setting has been added that can disable this feature.
### Issues

<!-- Does your pull request close/fix any issues reported? -->
Closes #208 
### Have You...?

- [x] I have read the [Contributing Guidelines](https://github.com/typicalbot/typicalbot/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [pull request template](https://github.com/typicalbot/typicalbot/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
- [x] I have checked open [pull requests](https://github.com/typicalbot/typicalbot/pulls) for upcoming features and fixes.
