### PR TITLE
fix: `randomuser` not getting offline users by default

### DIFF
--- a/src/commands/utility/randomuser.ts
+++ b/src/commands/utility/randomuser.ts
@@ -2,14 +2,11 @@ import Command from '../../lib/structures/Command';
 import { TypicalGuildMessage } from '../../lib/types/typicalbot';
 import { Modes } from '../../lib/utils/constants';
 
-const regex = /(-o(?:nline)?\s)?/i;
-
 export default class extends Command {
     aliases = ['ruser'];
     mode = Modes.LITE;
 
     execute(message: TypicalGuildMessage, parameters: string) {
-        const args = regex.exec(parameters);
         const role = parameters
             ? message.guild.roles.cache.get(parameters)
                 || message.guild.roles.cache.find((role) => role.name.toLowerCase() === parameters.toLowerCase())
@@ -17,7 +14,7 @@ export default class extends Command {
 
         const members = role
             ? role.members.filter((m) => !m.user.bot)
-            : args
+            : ['-o', '-online'].includes(parameters)
                 ? message.guild.members.cache.filter((m) => m.presence.status !== 'offline' && !m.user.bot)
                 : message.guild.members.cache.filter((m) => !m.user.bot);
 


### PR DESCRIPTION
## Pull Request

### Items Changed

- [x] Commands
- [ ] Events
- [ ] Handlers
- [ ] Structures
- [ ] Tasks
- [ ] Documentation
- [ ] Other: ______

### Description

<!-- Describe the changes you made. -->
This PR allows getting offline users when doing `$randomuser`. The issue was that the args variable was ALWAYS an array this became truthy and therefore passed for the first in the ternary. Regexes are best avoided when possible to do it in easier ways imo.

### Issues

<!-- Does your pull request close/fix any issues reported? -->
Closes #234 

### Have You...?

- [x] I have read the [Contributing Guidelines](https://github.com/typicalbot/typicalbot/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [pull request template](https://github.com/typicalbot/typicalbot/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
- [x] I have checked open [pull requests](https://github.com/typicalbot/typicalbot/pulls) for upcoming features and fixes.
