### PR TITLE
fix: edited cases don't display moderator id

### DIFF
--- a/src/handlers/ModerationLogHandler.ts
+++ b/src/handlers/ModerationLogHandler.ts
@@ -66,7 +66,7 @@ export default class ModerationLogHandler {
             : '';
 
         return message.edit(embed
-            .setAuthor(moderator.tag, moderator.displayAvatarURL())
+            .setAuthor(`${moderator.tag} (${moderator.id})`, moderator.displayAvatarURL())
             .setDescription([
                 start,
                 message.translate('moderation/modlog:REASON', {


### PR DESCRIPTION
## Pull Request

### Items Changed

- [ ] Commands
- [ ] Events
- [x] Handlers
- [ ] Structures
- [ ] Tasks
- [ ] Documentation
- [ ] Other: ______

### Description

Updated edit function in modlog handler

### Issues

Issue was brought up in Discord server, no GitHub issue created.

### Have You...?

- [x] I have read the [Contributing Guidelines](https://github.com/typicalbot/typicalbot/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [pull request template](https://github.com/typicalbot/typicalbot/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
- [x] I have checked open [pull requests](https://github.com/typicalbot/typicalbot/pulls) for upcoming features and fixes.
