### PR TITLE
fix: remove junk at the end of roleplay messages

### DIFF
--- a/etc/languages/de-DE/roleplay/punch.json
+++ b/etc/languages/de-DE/roleplay/punch.json
@@ -3,5 +3,5 @@
     "USAGE": "punch [@Nutzer]",
     "SELF": " hör auf dich selber zu schlagen! :punch:",
     "RESPONSE": "hat gerade {{user}} geschlagen! :punch:",
-    "RESPONSE_JAW": "hat gerade {{user}} geschlagen! :punch: Oh, dang! Gerade ins Kinn! Das muss weh getan haben!'"
+    "RESPONSE_JAW": "hat gerade {{user}} geschlagen! :punch: Oh, dang! Gerade ins Kinn! Das muss weh getan haben!"
 }

--- a/etc/languages/de-DE/roleplay/slap.json
+++ b/etc/languages/de-DE/roleplay/slap.json
@@ -3,5 +3,5 @@
     "USAGE": "slap [@Nutzer]",
     "SELF": ", hör auf dich selber zu schlagen! :dizzy_face::wave:",
     "RESPONSE": "hat gerade {{user}} geschlagen! :dizzy_face::wave:",
-    "RESPONSE_HURT": "hat gerade {{user}}getrübt! :dizzy_face::wave: Oh, dang! Das muss weh tun!`"
+    "RESPONSE_HURT": "hat gerade {{user}}getrübt! :dizzy_face::wave: Oh, dang! Das muss weh tun!"
 }

--- a/etc/languages/en-US/roleplay/punch.json
+++ b/etc/languages/en-US/roleplay/punch.json
@@ -3,5 +3,5 @@
   "USAGE": "punch [@user]",
   "SELF": " stop hitting yourself! :punch:",
   "RESPONSE": "just punched {{user}}! :punch:",
-  "RESPONSE_JAW": "just punched {{user}}! :punch: Oh, dang! Right to the jaw! That must've hurt!'"
+  "RESPONSE_JAW": "just punched {{user}}! :punch: Oh, dang! Right to the jaw! That must've hurt!"
 }

--- a/etc/languages/en-US/roleplay/slap.json
+++ b/etc/languages/en-US/roleplay/slap.json
@@ -3,5 +3,5 @@
   "USAGE": "slap [@user]",
   "SELF": ", stop hitting yourself! :dizzy_face::wave:",
   "RESPONSE": "just slapped {{user}}! :dizzy_face::wave:",
-  "RESPONSE_HURT": "just slapped {{user}}! :dizzy_face::wave: Oh, dang! That must've hurt!`"
+  "RESPONSE_HURT": "just slapped {{user}}! :dizzy_face::wave: Oh, dang! That must've hurt!"
 }

--- a/etc/languages/sl-SL/roleplay/punch.json
+++ b/etc/languages/sl-SL/roleplay/punch.json
@@ -3,5 +3,5 @@
     "USAGE": "udari [@uporabnik]",
     "SELF": " nehaj se udarjati! :punch:",
     "RESPONSE": "je pravkar udaril {{user}}! :punch:",
-    "RESPONSE_JAW": "je pravkar udaril {{user}}! :punch: O, šment! Pa ravno v čeljust ga je! To mora boleti! '"
+    "RESPONSE_JAW": "je pravkar udaril {{user}}! :punch: O, šment! Pa ravno v čeljust ga je! To mora boleti!"
 }

--- a/etc/languages/tr-TR/roleplay/slap.json
+++ b/etc/languages/tr-TR/roleplay/slap.json
@@ -3,5 +3,5 @@
     "USAGE": "slap [@user]",
     "SELF": ", kendine vurmayı kes! :dizzy_face::wave:",
     "RESPONSE": "az önce {{user}} kullanıcısını tokatladı! :dizzy_face::wave:",
-    "RESPONSE_HURT": "az önce {{user}} kullanıcısını tokatladı! :dizzy_face::wave: Lanet olsun! Acıtmış olmalı!`"
+    "RESPONSE_HURT": "az önce {{user}} kullanıcısını tokatladı! :dizzy_face::wave: Lanet olsun! Acıtmış olmalı!"
 }


### PR DESCRIPTION
## Pull Request

### Items Changed

- [ ] Commands
- [ ] Events
- [ ] Handlers
- [ ] Structures
- [ ] Tasks
- [ ] Documentation
- [x] Other: Messages

### Description

There are unneeded apostrophes/backticks at the end of some of the roleplay messages. I removed them.

### Issues

<!-- Does your pull request close/fix any issues reported? -->
N/A

### Have You...?

- [x] I have read the [Contributing Guidelines](https://github.com/typicalbot/typicalbot/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [pull request template](https://github.com/typicalbot/typicalbot/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
- [x] I have checked open [pull requests](https://github.com/typicalbot/typicalbot/pulls) for upcoming features and fixes.
